### PR TITLE
Safer default for cresult_variable_name

### DIFF
--- a/Source/Swig/cwrap.c
+++ b/Source/Swig/cwrap.c
@@ -15,7 +15,7 @@
 #include "swig.h"
 #include "cparse.h"
 
-static const char *cresult_variable_name = "result";
+static const char *cresult_variable_name = "_swig_result";
 
 static Parm *nonvoid_parms(Parm *p) {
   if (p) {


### PR DESCRIPTION
If a wrapped method has a parameter called `result`, compilation of the resulting C++ unit will fail.

A safer default name for `cresult_variable_name` is `"_swig_result"` as it makes a collision with a parameter name much less likely.

A full fix would be a unique and deterministically chosen name. In the meantime, this workaround is simple and I believe it's strictly better than the current value.

It's also spiritually equivalent to the workaround described here: https://github.com/swig/swig/issues/644